### PR TITLE
Show full path in breadcrumbs

### DIFF
--- a/tpl_parts/tpl_pageheader.html
+++ b/tpl_parts/tpl_pageheader.html
@@ -1,4 +1,4 @@
-<?php global $conf, $lang, $ACT, $INFO, $ID, $DOKU_BASE ?>
+<?php global $conf, $lang, $ACT, $INFO, $ID, $DOKU_BASE, $INPUT?>
 
 <div id="pageheader">
 	<!-- Messages -->
@@ -18,36 +18,38 @@
 				<?php endif ?>
 			<?php } else { ?>
 				<?php
-					if ($ACT == "show") {
+					if ("show" == $ACT) {
 						//build full path
 						$orgValue = $conf['youarehere'];
 						$conf['youarehere'] = true;
 						$youarehere = tpl_youarehere('» ', true);
 						$conf['youarehere'] = $orgValue;
-						
+
 						//remove text youarehere
 						$youarehere = preg_replace('/.*?bchead.*?span>/', '', $youarehere);
-						
+
 						//replace home
 						$youarehere = preg_replace('/.*?home.*?span>/', '<span class="home"><a href="'.tpl_getConf('startpage').'">'.tpl_getlang("breadcrumbs_docs").'</a></span>', $youarehere);
-						
+
 						//replace current page
 						$matches = array();
 						preg_match_all('/<bdi>.*?<\/bdi>/', $youarehere, $matches);
-						
+
 						$last = end($matches[0]);
 						if (false === $last) {
 							$youarehere .= '» <bdi>'.tpl_pagetitle(null, true).'</bdi>';
 						} else {
 							$youarehere = str_replace($last, '<bdi>'.tpl_pagetitle(null, true).'</bdi>', $youarehere);
 						}
-						
-					} else if ($ACT == "search") {
+
+					} else if ("search" == $ACT ) {
 						$youarehere = '<span class="home"><a href="'.tpl_getConf('startpage').'">'.tpl_getlang("breadcrumbs_docs").'</a></span>» <bdi>'.tpl_pagetitle(null, true).'</bdi>';
+					} else if ("showtag" == $ACT) {
+						$youarehere = '<span class="home"><a href="'.tpl_getConf('startpage').'">'.tpl_getlang("breadcrumbs_docs").'</a></span>» <bdi>TAG: '.hsc(str_replace('_', ' ', $INPUT->str('tag'))).'</bdi>';
 					} else {
 						$youarehere = '<span class="admin"><a href="'.wl($ID,array('do'=>'admin'),true,'&').'">'.tpl_getlang("breadcrumbs_admin").'</a></span>» <bdi>'.tpl_pagetitle(null, true).'</bdi>';
 					}
-					
+
 					echo $youarehere;
 					?>
 			<?php } ?>

--- a/tpl_parts/tpl_pageheader.html
+++ b/tpl_parts/tpl_pageheader.html
@@ -1,4 +1,4 @@
-<?php global $conf, $lang, $ACT, $INFO, $ID, $DOKU_BASE, $INPUT?>
+<?php global $conf, $lang, $ACT, $INFO, $ID, $DOKU_BASE, $INPUT ?>
 
 <div id="pageheader">
 	<!-- Messages -->

--- a/tpl_parts/tpl_pageheader.html
+++ b/tpl_parts/tpl_pageheader.html
@@ -17,12 +17,39 @@
 					<div class="trace"><?php tpl_breadcrumbs() ?></div>
 				<?php endif ?>
 			<?php } else { ?>
-				<?php if ($ACT == "show" || $ACT == "search") { ?>
-				<span class="home"><a href="<?php echo tpl_getConf('startpage'); ?>"><?php echo tpl_getlang("breadcrumbs_docs"); ?></a></span>
-				<?php } else { ?>
-				<span class="admin"><a href="<?php echo wl($ID,array('do'=>'admin'),true,'&'); ?>"><?php echo tpl_getlang("breadcrumbs_admin"); ?></a></span>
-				<?php } ?>
-				»  <bdi><?php tpl_pagetitle(); ?></bdi>
+				<?php
+					if ($ACT == "show") {
+						//build full path
+						$orgValue = $conf['youarehere'];
+						$conf['youarehere'] = true;
+						$youarehere = tpl_youarehere('» ', true);
+						$conf['youarehere'] = $orgValue;
+						
+						//remove text youarehere
+						$youarehere = preg_replace('/.*?bchead.*?span>/', '', $youarehere);
+						
+						//replace home
+						$youarehere = preg_replace('/.*?home.*?span>/', '<span class="home"><a href="'.tpl_getConf('startpage').'">'.tpl_getlang("breadcrumbs_docs").'</a></span>', $youarehere);
+						
+						//replace current page
+						$matches = array();
+						preg_match_all('/<bdi>.*?<\/bdi>/', $youarehere, $matches);
+						
+						$last = end($matches[0]);
+						if (false === $last) {
+							$youarehere .= '» <bdi>'.tpl_pagetitle(null, true).'</bdi>';
+						} else {
+							$youarehere = str_replace($last, '<bdi>'.tpl_pagetitle(null, true).'</bdi>', $youarehere);
+						}
+						
+					} else if ($ACT == "search") {
+						$youarehere = '<span class="home"><a href="'.tpl_getConf('startpage').'">'.tpl_getlang("breadcrumbs_docs").'</a></span>» <bdi>'.tpl_pagetitle(null, true).'</bdi>';
+					} else {
+						$youarehere = '<span class="admin"><a href="'.wl($ID,array('do'=>'admin'),true,'&').'">'.tpl_getlang("breadcrumbs_admin").'</a></span>» <bdi>'.tpl_pagetitle(null, true).'</bdi>';
+					}
+					
+					echo $youarehere;
+					?>
 			<?php } ?>
 		</div>
 


### PR DESCRIPTION
Show full path in breadcrumbs instead of only home link and title of current page: eg: 'home >> ns1 >> ns2 >> page' instead of 'home >> page'

![obraz](https://github.com/user-attachments/assets/bebf2c43-2087-4085-a549-196761e6a55f)

![obraz](https://github.com/user-attachments/assets/72205286-0ebe-4219-a190-83504b160180)
