### PR TITLE
Restore css for code tag and proper fix for CodePrism

### DIFF
--- a/css/basic.css
+++ b/css/basic.css
@@ -140,10 +140,22 @@ pre
 	font-family: SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,Courier,monospace;
 	font-size: 12px;
 	line-height: 1.4;
-    margin: 1px 0 24px;
+    	margin: 1px 0 24px;
 	overflow: auto;
 	padding: 12px;
 	white-space: pre;
+}
+
+:not(pre) > code
+{
+	background-color: __background_monospace__;
+	border: 1px solid __border_monospace__;
+	color: __text_monospace__;
+	font-family: SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, Courier, monospace;
+	font-size: 75%;
+	max-width: 100%;
+	padding: 2px 5px;
+	overflow-wrap: break-word;
 }
 
 hr

--- a/css/basic.css
+++ b/css/basic.css
@@ -146,7 +146,7 @@ pre
 	white-space: pre;
 }
 
-:not(pre) > code
+:not(pre[class*=language-]) > code
 {
 	background-color: __background_monospace__;
 	border: 1px solid __border_monospace__;


### PR DESCRIPTION
css for code tag is necessary, without it elements inside "TT" ('') are bad styled. With this patch (better css selector), TT elements are correct styled and CodePrism works