### PR TITLE
Little fix to center wiki title in header in mobile view

### DIFF
--- a/css/mobileheader.css
+++ b/css/mobileheader.css
@@ -41,7 +41,7 @@
 	#mobileheader #btn-mobilemenu
 	{
 		cursor:pointer;
-		position: relative;
+		position: absolute;
 		width: 30px;
 		height: 30px;
 	}


### PR DESCRIPTION
This was very annoying for me that title is not in the middle of the screen.