### PR TITLE
Font-awesome emojis limited to their scope

### DIFF
--- a/css/basic.css
+++ b/css/basic.css
@@ -21,7 +21,7 @@ body
 {
     background-color: __background_alt__;
     color: __text__;
-    font-family: Lato,proxima-nova,"Helvetica Neue",Arial,sans-serif,system-ui,"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji","Font Awesome 5 Free";
+    font-family: Lato,proxima-nova,"Helvetica Neue",Arial,sans-serif,system-ui,"Apple Color Emoji","Segoe UI Emoji","Noto Color Emoji","Font Awesome 5 Free";
     font-weight: 400;
 	margin: 0;
     min-height: 100%;

--- a/css/basic.css
+++ b/css/basic.css
@@ -21,15 +21,11 @@ body
 {
     background-color: __background_alt__;
     color: __text__;
-    font-family: Lato,proxima-nova,"Helvetica Neue",Arial,sans-serif;
+    font-family: Lato,proxima-nova,"Helvetica Neue",Arial,sans-serif,system-ui,"Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji","Font Awesome 5 Free";
     font-weight: 400;
 	margin: 0;
     min-height: 100%;
 	overflow-y: hidden;
-}
-
-.fa, .fas, .far, .fab {
-  font-family: 'Font Awesome 5 Free';
 }
 
 a

--- a/css/basic.css
+++ b/css/basic.css
@@ -21,11 +21,15 @@ body
 {
     background-color: __background_alt__;
     color: __text__;
-    font-family: Lato,proxima-nova,"Helvetica Neue",Arial,sans-serif,"Font Awesome 5 Free";
+    font-family: Lato,proxima-nova,"Helvetica Neue",Arial,sans-serif;
     font-weight: 400;
 	margin: 0;
     min-height: 100%;
 	overflow-y: hidden;
+}
+
+.fa, .fas, .far, .fab {
+  font-family: 'Font Awesome 5 Free';
 }
 
 a


### PR DESCRIPTION
Actually, the template replaces all native emoji fonts with Font-Awesome ones. This PR limits the scope of Font-Awesome icons for their counterparts only. It uses the system default font, then fallback to system-specific ones (Apple, Windows and Android), then use Font Awesome. Font Awesome icons will always be rendered by Font Awesome (e.g. admonitions) since their Unicode code do not exist on other fonts.

E.g. "✅" becomes:

Before this PR:
<img width="428" alt="image" src="https://github.com/user-attachments/assets/f2eb9054-1534-4fdf-b0aa-d4a071d5cc01" />

After this PR:
<img width="428" alt="image" src="https://github.com/user-attachments/assets/4f7be52d-6e2b-4c08-86c2-6f8a7b9d6ff1" />
