### PR TITLE
Patch 11

### DIFF
--- a/css/_admin.css
+++ b/css/_admin.css
@@ -484,6 +484,12 @@ div#user__manager > div.import_users
 	width: 100%;
 }
 
+#extension__list section.extension > .screenshot .popularity img {
+    vertical-align: middle;
+    height: 1.2rem;
+    width: auto;
+}
+
 #dw__editform div.editBar
 {
 	display: flex;

--- a/css/content.css
+++ b/css/content.css
@@ -59,11 +59,6 @@
 	overflow-x: auto;
 }
 
-#dokuwiki__content svg
-{
-	height: auto;
-}
-
 #dokuwiki__content img,
 #dokuwiki__content svg
 {


### PR DESCRIPTION
<details><summary>Before this PR, notice that the warning sign and popularity contest icons are huge:
</summary><img width="1122" alt="image" src="https://github.com/user-attachments/assets/902954c5-75ef-4960-b20b-3fa7c0db33f1" /></details>

<details><summary>After this PR:
</summary><img src="https://github.com/user-attachments/assets/5e776452-c829-4bb4-855f-bfa14e3d4fe0" width="1122" alt="image"></details>